### PR TITLE
Lists not strings

### DIFF
--- a/codebreaker.el
+++ b/codebreaker.el
@@ -1,13 +1,9 @@
 (require 'dash)
-(require 'cl)
 
 ;; some constants
 (setq cb/color-pegs '("R" "G" "Y" "B" "W" "P"))
 (setq cb/puzzle-size 4)
       
-(defun cb/zip (ar1 ar2)
-  (mapcar* #'cons ar1 ar2))
-
 ;; I need this function because emacs-lisp `remove` removes all copies of member
 (defun cb/remove (member l)
   "Return a copy of L where one instance of MEMBER has been removed."
@@ -15,48 +11,50 @@
 	( (equal member (car l)) (cdr l))
 	( t (cons (car l) (cb/remove member (cdr l))))))
 
-(defun cb/cons-match (c)
-  "Return true if the two parts of the cons cell C are equal."
-  (equal (car c) (cdr c)))
-
 (defun cb/generate-list (size candidates)
   "Generate a list of size SIZE from elements in CANDIDATES."
   (if (equal 0 size) '()
-    (cons (nth (random 6) candidates) (cb/generate-list (- size 1) candidates))))
+    (cons (seq-random-elt candidates) (cb/generate-list (- size 1) candidates))))
 
 (defun cb/count-black (guess solution)
-  "Return a count of how many pieces in the guess match the solution in color and notation."
-  (let (
-	(matched (-filter #'cb/cons-match (cb/zip guess solution))))
-    (length matched)))
-  
+  (cond ( (not guess) 0 )    ;; 0 if empty
+	( (equal (car guess) (car solution)) (+ 1 (cb/count-black (cdr guess) (cdr solution)))) ;; add if they match
+	( t (cb/count-black (cdr guess) (cdr solution))))) ;; if they do not match
+
 (defun cb/count-white (guess solution)
-  (let ( (unmatched (-filter (lambda (x) (not (cb/cons-match x))) (cb/zip guess solution))) )
-    (cb/count-xx (-map #'car unmatched) (-map #'cdr unmatched))
-    ))
+    (cb/count-white-r (remove-equal guess solution) (remove-equal solution guess)))
 
-(defun cb/count-xx (l1 l2)
-  "Helper counting function for counting whites."
-  (cond ( (not l1) 0)
-	( (member (car l1) l2) (+ 1 (cb/count-xx (cdr l1) (cb/remove (car l1) l2))))
-	( t (cb/count-xx (cdr l1) l2))))
+(defun remove-equal (main-l other-l)
+  (cond ( (not main-l) '() )
+	( (equal (car main-l) (car other-l)) (remove-equal (cdr main-l) (cdr other-l)))
+	( t (cons (car main-l) (remove-equal (cdr main-l) (cdr other-l))))))
 
+(defun cb/count-white-r (gl-short sl-short)
+  (let ( (first (car gl-short))
+	 (rest (cdr gl-short)))
+    (cond ( (not first) 0)
+	  ( (member first sl-short) (+ 1 (cb/count-white-r rest (cb/remove first sl-short))) )
+	  ( t (cb/count-white-r rest sl-short)))))
+
+(defun cb/input ()
+  "Waits for user to input guess and return it as list of chars"
+  (let ( (input (read-string ": ")))
+    (cdr (split-string input ""))))
 
 (defun cb/play-round (solution)
   "Play one round of the game given SOLUTION and returns t if the puzzle has been solved."
-  (let* ( (guess
-	   (read-string ": "))
+  (let* ( (guess (cb/input))
 	  (b    (cb/count-black guess solution))
 	  (w    (cb/count-white guess solution))
 	  )
-    (insert guess " .... " (number-to-string b) "." (number-to-string w) "\n")
+    (insert (string-join guess "") " .... " (number-to-string b) "." (number-to-string w) "\n")
     (= 4 b)))
 
 
 (defun cb/play-game ()
-  "Play a game of Mastermind."
+  "Play a game of code breaker."
   (interactive)
-  (let ( (solution (mapconcat #'identity (cb/generate-list cb/puzzle-size cb/color-pegs) ""))
+  (let ( (solution (cb/generate-list cb/puzzle-size cb/color-pegs))
 	 (count 1))
     (switch-to-buffer "*mastermind*")
     (insert "\n--------\n")

--- a/tests.el
+++ b/tests.el
@@ -5,20 +5,17 @@
 (package-initialize) ;; needed so (require 'dash) works
 (load-file "./codebreaker.el")
 
+
 ;; tests
 
-(ert-deftest test-cons-match ()
-  (should (cb/cons-match '( 1 . 1)))
-  (should (not (cb/cons-match '(1 . 2)))))
-
 (ert-deftest test-count-black ()
-  (should (equal 0 (cb/count-black "RRRB" "BBBR")))
-  (should (equal 1 (cb/count-black "RRRB" "RBBG")))
-  (should (equal 1 (cb/count-black "RRRB" "RGBR"))))
+  (should (equal 0 (cb/count-black '("R" "R" "R" "B") '("B" "B" "B" "R"))))
+  (should (equal 1 (cb/count-black '("R" "R" "R" "B") '("R" "B" "B" "G"))))
+  (should (equal 1 (cb/count-black '("R" "R" "R" "B") '("R" "G" "B" "R")))))
 
 (ert-deftest test-count-white ()
-  (should (equal 0 (cb/count-white "RRRB" "GGGY")))
-  (should (equal 2 (cb/count-white "RRRB" "BBBR"))))
+  (should (equal 0 (cb/count-white '("R" "R" "R" "B") '("G" "G" "G" "Y"))))
+  (should (equal 2 (cb/count-white '("R" "R" "R" "B") '("B" "B" "B" "R")))))
 
 (ert-deftest test-cb-remove ()
   (should (equal '(1 3 2) (cb/remove 2 '(1 2 3 2))))

--- a/tests.el
+++ b/tests.el
@@ -8,20 +8,15 @@
 
 ;; tests
 
-(ert-deftest test-count-black ()
-  (should (equal 0 (cb/count-black '("R" "R" "R" "B") '("B" "B" "B" "R"))))
-  (should (equal 1 (cb/count-black '("R" "R" "R" "B") '("R" "B" "B" "G"))))
-  (should (equal 1 (cb/count-black '("R" "R" "R" "B") '("R" "G" "B" "R")))))
-
-(ert-deftest test-count-white ()
-  (should (equal 0 (cb/count-white '("R" "R" "R" "B") '("G" "G" "G" "Y"))))
-  (should (equal 2 (cb/count-white '("R" "R" "R" "B") '("B" "B" "B" "R")))))
-
 (ert-deftest test-cb-remove ()
   (should (equal '(1 3 2) (cb/remove 2 '(1 2 3 2))))
   (should (equal '(1 2 2) (cb/remove 3 '(1 2 3 2))))
   (should (equal '(1 2 3) (cb/remove 4 '(1 2 3)))))
 
+(ert-deftest test-count-pegs ()
+  (should (equal '(0 . 2) (cb/count-pegs '("R" "R" "R" "B") '("B" "B" "B" "R"))))
+  (should (equal '(1 . 1) (cb/count-pegs '("R" "R" "R" "B") '("R" "B" "B" "G"))))
+  (should (equal '(1 . 2) (cb/count-pegs '("R" "R" "R" "B") '("R" "G" "B" "R")))))
 
 ;; run all defined tests
 (ert-run-tests-batch)


### PR DESCRIPTION
Changed the implementation so that the majority of the code treats guesses and solutions as lists of strings instead of strings. Done because I was finding myself splitting things into lists all the time.
